### PR TITLE
Adding .dockerignore file.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.idea
+.DS_Store
+Gemfile.lock


### PR DESCRIPTION
Dockerignore file resolves issues of Gemfile.lock being different across machines. Added a few other common items that should be ignored when building a new container.