### PR TITLE
Deploy Docker containers from with the gitlab CI script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,9 +10,9 @@ sync-repo:
   before_script:
     # add the MITRE certificates to the docker image
     - apk update && apk add git openssh-client ca-certificates
-    - wget -O /usr/local/share/ca-certificates/MITRE_BA_Root.crt http://pki.mitre.org/MITRE%20BA%20Root.crt
-    - wget -O /usr/local/share/ca-certificates/MITRE_BA_NPE_CA-1.crt http://pki.mitre.org/MITRE%20BA%20NPE%20CA-1.crt
-    - wget -O /usr/local/share/ca-certificates/MITRE_BA_NPE_CA-3.crt http://pki.mitre.org/MITRE%20BA%20NPE%20CA-3.crt
+    - wget -O /usr/local/share/ca-certificates/MITRE_BA_Root.crt $CRT_R
+    - wget -O /usr/local/share/ca-certificates/MITRE_BA_NPE_CA-1.crt $CRT_1
+    - wget -O /usr/local/share/ca-certificates/MITRE_BA_NPE_CA-3.crt $CRT_3
     - update-ca-certificates
 
     # create a file called push_key that contains the $GITLAB_PUSH_KEY
@@ -33,3 +33,30 @@ sync-repo:
     - cd heimdall
     - git remote add github git@gitlab.mitre.org:inspec/heimdall.git
     - ssh-agent sh -c 'ssh-add ~/push_key; git push --tags github master || true' # REMOTE NAME from previous line
+build:
+  stage: build
+  image: docker:latest
+
+  before_script:
+    # add the MITRE certificates to the docker image
+    - apk update && apk add git openssh-client ca-certificates py-pip
+    - wget -O /usr/local/share/ca-certificates/MITRE_BA_Root.crt $CRT_R
+    - wget -O /usr/local/share/ca-certificates/MITRE_BA_NPE_CA-1.crt $CRT_1
+    - wget -O /usr/local/share/ca-certificates/MITRE_BA_NPE_CA-3.crt $CRT_3
+    - update-ca-certificates
+  
+  script:
+    # Configuration modification purely for inspec-dev
+    # For service behind the MITRE Firewall connecting to gitlab.mitre.org 
+    - echo "$SED_PROXY" > sed-script-file
+    - grep MITRE_BA_Root dockerfiles/heimdall/Dockerfile || sed -f sed-script-file -i"" dockerfiles/heimdall/Dockerfile
+    # Swap to port 3001, and bind to all interfaces
+    - sed -e 's#3000#3001#g' -i"" dockerfiles/heimdall/Dockerfile
+    - sed -e 's#3000#3001#g' -i"" docker-compose.yml
+    - sed -e 's#3001"]#3001", "-b", "0.0.0.0"]#g' -i"" dockerfiles/heimdall/Dockerfile
+    - pip install docker-compose
+    - docker-compose down
+    - docker-compose build
+    - docker-compose run web rake db:migrate
+    - docker-compose up -d
+    - docker system prune

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,14 @@
 version: '3'
 
 services:
+  # If you wish to use a db other than mongo, this is 100% wrong
   db:
     build: "./dockerfiles/database"
     volumes:
-      - ./mongo_data:/data/db
-    ports:
-      - "27017:27017"
-      - "28017:28017"
+      - mongo_data:/data/db
+    expose:
+      - "27017"
+      - "28017"
   web:
     build:
       context: ./
@@ -16,3 +17,6 @@ services:
       - "3000:3000"
     depends_on:
       - "db"
+
+volumes:
+  mongo_data:

--- a/dockerfiles/database/Dockerfile
+++ b/dockerfiles/database/Dockerfile
@@ -1,8 +1,11 @@
 # Pull base image.
 FROM mongo
 
-# Define mountable directories.
-VOLUME ["/data/db"]
+## Define mountable directories.
+## VOLUME ["/data/db"] 
+#^ This should only be done if updates are considered destructive
+#^ https://github.com/moby/moby/issues/30647 Persistent db's are
+#^ supposed to be constructed from named volumes in docker-compose.yml
 
 # Define working directory.
 WORKDIR /data

--- a/dockerfiles/heimdall/Dockerfile
+++ b/dockerfiles/heimdall/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.2
+FROM ruby:2.4.4
 
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
 
@@ -17,6 +17,7 @@ ADD . .
 RUN mv config/mongoid.yml config/mongoid.yml.orig
 RUN mv config/mongoid.yml.docker config/mongoid.yml
 
-CMD ["bundle", "exec", "rails", "server"]
-
 EXPOSE 3000
+
+CMD ["bundle", "exec", "rails", "server", "-p", "3000"]
+


### PR DESCRIPTION
Deployment requires the GITLAB CI container have access to docker,
the proxy settings for MITRE, and the certs for gitlab.