### PR TITLE
Does not encrypt secrets file, but does add an autogen script for docker

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,6 +46,7 @@ build:
     - update-ca-certificates
   
   script:
+    - rsync --exclude=.git --exclude-from=.gitignore --delete -prult ./ /var/www/heimdall
     # Configuration modification purely for inspec-dev
     # For service behind the MITRE Firewall connecting to gitlab.mitre.org 
     - echo "$SED_PROXY" > sed-script-file
@@ -53,10 +54,7 @@ build:
     # Swap to port 3001, and bind to all interfaces
     - sed -e 's#3000#3001#g' -i"" dockerfiles/heimdall/Dockerfile
     - sed -e 's#3000#3001#g' -i"" docker-compose.yml
-    - sed -e 's#3001"]#3001", "-b", "0.0.0.0"]#g' -i"" dockerfiles/heimdall/Dockerfile
     - pip install docker-compose
-    - docker-compose down
-    - docker-compose build
-    - docker-compose run web rake db:migrate
+    - ./docker_build.sh
     - docker-compose up -d
     - docker system prune

--- a/README.md
+++ b/README.md
@@ -22,9 +22,34 @@ You also need to run these commands if you perform any changes to the code base 
 ### Running Docker Container
 1. Run the following command in a terminal window:
    1. `docker-compose up`
-2. Go to `127.0.0.1:3000` in a web browser
+2. Go to `127.0.0.1:3000/heimdall` in a web browser
 
-#
+### Configuration
+
+See docker-compose.yml for container configuration
+
+##### Host container off relative url
+
+Delete RAILS\_RELATIVE\_URL\_ROOT line from docker-compose.yml and dockerfiles/heimdall/Dockerfile
+
+##### Switch container to dev mode
+
+Delete RAILS\_ENV lines from from docker-compose.yml and dockerfiles/heimdall/Dockerfile
+
+#### Get keys
+
+List containers, and take note of the full name of the heimdall\_web image's container. *The container name is the rightmost column NAME.*
+
+``` bash
+docker container ps
+``` 
+
+Then copy the secrets file out of the container, replace heimdall\_web\_1 with your container's name.
+
+``` bash
+docker cp heimdall_web_1:/var/www/heimdall/config/secrets.yml  
+```
+
 
 This README would normally document whatever steps are necessary to get the
 application up and running.

--- a/config.ru
+++ b/config.ru
@@ -6,4 +6,4 @@ map ENV['RAILS_RELATIVE_URL_ROOT'] || '/' do
   run Rails.application
 end
 
-run Rails.application
+# run Rails.application

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   # Attempt to read encrypted secrets from `config/secrets.yml.enc`.
   # Requires an encryption key in `ENV["RAILS_MASTER_KEY"]` or
   # `config/secrets.yml.key`.
-  config.read_encrypted_secrets = true
+  config.read_encrypted_secrets = false
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.

--- a/config/mongoid.yml.docker
+++ b/config/mongoid.yml.docker
@@ -155,3 +155,31 @@ test:
         read:
           mode: :primary
         max_pool_size: 1
+
+production:
+  # This starts the session configuration settings. You may have as
+  # many sessions as you like, but you must have at least 1 named
+  # 'default'.
+  clients:
+    # Define the default session.
+    default:
+      # A session can have any number of hosts. Usually 1 for a single
+      # server setup, and at least 3 for a replica set. Hosts must be
+      # an array of host:port pairs. This session is single server.
+      hosts:
+        - db
+      # Define the default database name.
+      database: heimdall2_production
+      # Since this database points at a session connected to MongoHQ, we must
+      # provide the authentication details.
+      #username: user
+      #password: password
+  # Here we put the Mongoid specific configuration options. These are explained
+  # in more detail next.
+  options:
+    include_root_in_json: false
+    include_type_for_serialization: false
+    scope_overwrite_exception: false
+    raise_not_found_error: false
+    use_activesupport_time_zone: false
+    use_utc: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
   # If you wish to use a db other than mongo, this is 100% wrong
@@ -13,6 +13,15 @@ services:
     build:
       context: ./
       dockerfile: ./dockerfiles/heimdall/Dockerfile
+    
+    environment:
+      RAILS_SERVE_STATIC_FILES: "true"
+      RAILS_ENV: production
+      # The rails relative url is not necessary for all builds it can be fully
+      # removed if you wish to host off of '/'. Also, you will have to remove
+      # the relative url from dockerfiles/heimdall/Dockerfile
+      RAILS_RELATIVE_URL_ROOT: /heimdall
+
     ports:
       - "3000:3000"
     depends_on:

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -2,5 +2,8 @@
 
 set -xe
 
+# build db and web if needed
 docker-compose build
-docker-compose run web rake db:create
+# update db state
+docker-compose run web rake db:migrate
+

--- a/dockerfiles/heimdall/Dockerfile
+++ b/dockerfiles/heimdall/Dockerfile
@@ -12,12 +12,23 @@ ADD Gemfile Gemfile
 
 RUN gem install bundler && bundle install --jobs 20 --retry 5
 
+# Deploy production server to container
+ENV RAILS_ENV production
+ENV RAILS_RELATIVE_URL_ROOT /heimdall
+
 ADD . .
 
 RUN mv config/mongoid.yml config/mongoid.yml.orig
 RUN mv config/mongoid.yml.docker config/mongoid.yml
 
+# Generate secrets, potentially not if it already exists and is well formatted
+RUN ./gen-secrets.sh
+
+# precompile is only necessary for production builds
+RUN bundle exec rake assets:precompile
+
+RUN env
+
 EXPOSE 3000
 
-CMD ["bundle", "exec", "rails", "server", "-p", "3000"]
-
+CMD ["bundle", "exec", "rails", "server", "-p", "3000", "-b", "0.0.0.0"]

--- a/gen-secrets.sh
+++ b/gen-secrets.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+
+if [[ ! -a config/secrets.yml ]]
+then
+	echo "Generated secrets."
+	cat >config/secrets.yml <<EOF 
+development:
+  secret_key_base: d26decda541d849368ddc0655d5fd63bfb246935443eedb1ab2fb15762161f6da3ad665aeed166bfd86b6f43ce87f62fabad9523ea5e6a0b29dbd49d6aba7502
+  cipher_password: 'cipher_password'
+  cipher_salt: 'cipher_salt'
+
+test:
+  secret_key_base: c432c2a7954794eaa017fc50f68a1877d7bffa761f26c2b2cf50a43f40f5f387d933bd51bc91d4e33fcee02cc6728a698bfcd6b276c132739435282e08ef87c7
+  cipher_password: 'cipher_password'
+  cipher_salt: 'cipher_salt'
+
+# Do not keep production secrets in the unencrypted secrets file.
+# Instead, either read values from the environment.
+# Or, use \`bin/rails secrets:setup\` to configure encrypted secrets
+# and move the \`production:\` environment over there.
+
+production:
+  secret_key_base: `openssl rand -hex 64`
+  cipher_password: `openssl rand -hex 64`
+  cipher_salt: `openssl rand -hex 32`
+EOF
+
+elif [[ $(grep ENV config/secrets.yml) ]]
+then
+	cat <<-EOF 
+		config/secrets.yml exists, but is set to pull vars from the environment.
+		Rename it if you you'd like this build script to generate a secrets.yml 
+		with random values for keys. Or, if it does not pull from the env...
+	EOF
+	exit 2
+elif [[ $(grep production config/secrets.yml) ]]
+then
+	echo "Config already exists and has keys for production"
+
+fi
+
+chmod 640 config/secrets.yml


### PR DESCRIPTION
Relates to #36, this is a functional way of generating secrets, while
also setting up a production container.

Added comments for configuration required for a production container

Added comments explaining some minor configuration changes which 
can be made to switch run mode and base url

Add explanation of how to pull keys out of container to README.md