### PR TITLE
Add named volume in place of a docker secret issue #36

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .idea
 .DS_Store
 Gemfile.lock
+dockerfiles

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,22 +39,18 @@ build:
 
   before_script:
     # add the MITRE certificates to the docker image
-    - apk update && apk add git openssh-client ca-certificates py-pip
+    - apk update && apk add git openssh-client ca-certificates py-pip bash
     - wget -O /usr/local/share/ca-certificates/MITRE_BA_Root.crt $CRT_R
     - wget -O /usr/local/share/ca-certificates/MITRE_BA_NPE_CA-1.crt $CRT_1
     - wget -O /usr/local/share/ca-certificates/MITRE_BA_NPE_CA-3.crt $CRT_3
     - update-ca-certificates
   
   script:
-    - rsync --exclude=.git --exclude-from=.gitignore --delete -prult ./ /var/www/heimdall
     # Configuration modification purely for inspec-dev
     # For service behind the MITRE Firewall connecting to gitlab.mitre.org 
     - echo "$SED_PROXY" > sed-script-file
     - grep MITRE_BA_Root dockerfiles/heimdall/Dockerfile || sed -f sed-script-file -i"" dockerfiles/heimdall/Dockerfile
-    # Swap to port 3001, and bind to all interfaces
-    - sed -e 's#3000#3001#g' -i"" dockerfiles/heimdall/Dockerfile
-    - sed -e 's#3000#3001#g' -i"" docker-compose.yml
     - pip install docker-compose
+    - chmod +x docker_build.sh
     - ./docker_build.sh
     - docker-compose up -d
-    - docker system prune

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       context: ./
       dockerfile: ./dockerfiles/heimdall/Dockerfile
     
+    volumes:
+      - heimdall_secrets:/srv/secrets
     environment:
       RAILS_SERVE_STATIC_FILES: "true"
       RAILS_ENV: production
@@ -29,3 +31,4 @@ services:
 
 volumes:
   mongo_data:
+  heimdall_secrets:

--- a/dockerfiles/heimdall/Dockerfile
+++ b/dockerfiles/heimdall/Dockerfile
@@ -13,21 +13,22 @@ ADD Gemfile Gemfile
 RUN gem install bundler && bundle install --jobs 20 --retry 5
 
 # Deploy production server to container
-ENV RAILS_ENV production
-ENV RAILS_RELATIVE_URL_ROOT /heimdall
+ARG RAILS_ENV=production
+ARG RAILS_RELATIVE_URL_ROOT=/heimdall
 
 ADD . .
 
 RUN mv config/mongoid.yml config/mongoid.yml.orig
 RUN mv config/mongoid.yml.docker config/mongoid.yml
 
-# Generate secrets, potentially not if it already exists and is well formatted
-RUN ./gen-secrets.sh
-
 # precompile is only necessary for production builds
-RUN bundle exec rake assets:precompile
-
-RUN env
+RUN cp config/secrets.example.yml config/secrets.yml
+RUN bash -c "RAILS_ENV=$RAILS_ENV RAILS_RELATIVE_URL_ROOT=$RAILS_RELATIVE_URL_ROOT SECRET_KEY_BASE=$(openssl rand -hex 64) bundle exec rake assets:precompile"
+RUN rm config/secrets.yml
+RUN mkdir -p /srv/secrets/
+RUN touch /srv/secrets/secrets.yml
+RUN ln -s /srv/secrets/secrets.yml config/secrets.yml 
+RUN rm -rfv /srv/secrets
 
 EXPOSE 3000
 

--- a/gen-secrets.sh
+++ b/gen-secrets.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+[[ $1 == --overwrite ]]
+
+# Exit if volume exists
+docker inspect heimdall_heimdall_secrets && [[ $1 == --overwrite ]] || exit 0
+
+docker volume create heimdall_heimdall_secrets
+docker run -v heimdall_heimdall_secrets:/srv/secrets --name helper busybox true
 
 if [[ ! -a config/secrets.yml ]]
 then
@@ -39,5 +46,7 @@ then
 	echo "Config already exists and has keys for production"
 
 fi
+
+docker cp config/secrets.yml helper:/srv/secrets/
 
 chmod 640 config/secrets.yml


### PR DESCRIPTION
Changes to dockerfile are to point rails at the named volume, and to get
around asset precompilation failing due to the named volume not being
guaranteed available during the build process. This should be fine, as
assets do not make use of keys.

The gen-secrets script creates a named volume and populates it.