### PR TITLE
Fixed Treemap function, so that it respects baseurl

### DIFF
--- a/app/views/evaluations/show.html.erb
+++ b/app/views/evaluations/show.html.erb
@@ -1114,7 +1114,7 @@ document.addEventListener("turbolinks:load", function() {
   }
 
   function loadTreemapData(category, status) {
-    api_path = "/evaluations/" + evaluation_id + "/nist";
+    api_path = "<%= home_path %>" + "evaluations/" + evaluation_id + "/nist";
     if (category) {
       api_path += "/category/" + encodeURIComponent(category);
     }


### PR DESCRIPTION
Fix #41 for graphs not displaying when run from a baseurl
LoadTreemap is also used in the profile view. 
We alternatively should use `config.relative_url` instead as that is potentially more accurate for what we are trying to do. The home_path route is specified as the root route, but that could be swapped out.