### PR TITLE
Use official mitre/heimdall image instead of mine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     expose:
       - "27017"
   web:
-    image: rbclark/heimdall:latest
+    image: mitre/heimdall:latest
     environment:
       MONGO_TCP_ADDR: db
       MONGO_TCP_PORT: 27017


### PR DESCRIPTION
This shouldn't change how anything looks for users, just makes the image that we are using not on my Dockerhub account.